### PR TITLE
Fix broken countdown display

### DIFF
--- a/app/static/index.html
+++ b/app/static/index.html
@@ -3077,7 +3077,7 @@
             const hEl = document.getElementById('cd-hours');
             const mEl = document.getElementById('cd-mins');
             const sEl = document.getElementById('cd-secs');
-            if (!container || !timerEl) return;
+            if (!container || !dEl || !hEl || !mEl || !sEl) return;
             try {
                 const resp = await fetch('/api/user/event-expiration', { headers: token ? { 'Authorization': `Bearer ${token}` } : {} });
                 if (!resp.ok) { container.style.display = 'none'; return; }


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fix countdown display by correcting the initialization check for required HTML elements.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The `initExpirationCountdown` function was checking for `!timerEl`, but `timerEl` was never defined, causing the function to return prematurely and prevent the countdown from rendering. This change ensures the function proceeds only when all specific day, hour, minute, and second elements are present.

---
<a href="https://cursor.com/background-agent?bcId=bc-6df99a55-ff9c-42cf-a3b1-bd18f10bbaeb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6df99a55-ff9c-42cf-a3b1-bd18f10bbaeb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

