### PR TITLE
Tag matching photos with selfie

### DIFF
--- a/app/frontend/src/types/index.ts
+++ b/app/frontend/src/types/index.ts
@@ -17,6 +17,7 @@ export interface Photo {
   user_id?: number;
   photographer_id?: number;
   uploaded_at: string;
+  has_face_match?: boolean;
 }
 
 export interface FaceMatch {


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Add a visual 'Match' tag to photos in the gallery that correspond to the user's selfie to help verify face matching.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
This feature allows users to quickly see which photos have been identified as containing their face, enabling them to review the accuracy of the face matching algorithm directly within the photo gallery.

---
<a href="https://cursor.com/background-agent?bcId=bc-93d7a266-0d55-441c-9604-20409fa1d733">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-93d7a266-0d55-441c-9604-20409fa1d733">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

