### PR TITLE
Fix badge not showing on matching photos

### DIFF
--- a/app/schemas.py
+++ b/app/schemas.py
@@ -57,6 +57,11 @@ class Photo(PhotoBase):
     user_id: Optional[int] = None
     photographer_id: Optional[int] = None
     uploaded_at: datetime
+    # Champs additionnels renvoyés par l'API
+    content_type: Optional[str] = None
+    event_id: Optional[int] = None
+    event_name: Optional[str] = None
+    has_face_match: Optional[bool] = False
 
     class Config:
         from_attributes = True


### PR DESCRIPTION
Add `has_face_match` and `event_name` to the `Photo` schema to enable the ✅ badge display on selfie-matched photos in the General tab.

The backend API's `PhotoSchema` was missing `has_face_match` and `event_name`, causing FastAPI to strip these fields from the response. This prevented the frontend from receiving the necessary data to render the ✅ badge.

---
<a href="https://cursor.com/background-agent?bcId=bc-7a035579-e6ef-4f8d-be34-e1b68af3e7f0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7a035579-e6ef-4f8d-be34-e1b68af3e7f0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

